### PR TITLE
Linting and updates for Elixir v1.5

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,150 @@
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+  #
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      #
+      # Run any exec using `mix credo -C <name>`. If no exec name is given
+      # "default" is used.
+      #
+      name: "default",
+      #
+      # These are the files included in the analysis:
+      files: %{
+        #
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+      #
+        included: ["lib/", "src/", "web/", "apps/"],
+        excluded: [~r"/_build/", ~r"/deps/"]
+      },
+      #
+      # If you create your own checks, you must specify the source files for
+      # them here, so they can be loaded by Credo before running the analysis.
+      #
+      requires: [],
+      #
+      # Credo automatically checks for updates, like e.g. Hex does.
+      # You can disable this behaviour below:
+      #
+      check_for_updates: true,
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      #
+      strict: false,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      #
+      color: true,
+      #
+      # You can customize the parameters of any check by adding a second element
+      # to the tuple.
+      #
+      # To disable a check put `false` as second element:
+      #
+      #     {Credo.Check.Design.DuplicatedCode, false}
+      #
+      checks: [
+        {Credo.Check.Consistency.ExceptionNames},
+        {Credo.Check.Consistency.LineEndings},
+        {Credo.Check.Consistency.ParameterPatternMatching},
+        {Credo.Check.Consistency.SpaceAroundOperators},
+        {Credo.Check.Consistency.SpaceInParentheses},
+        {Credo.Check.Consistency.TabsOrSpaces},
+
+        # For some checks, like AliasUsage, you can only customize the priority
+        # Priority values are: `low, normal, high, higher`
+        #
+        {Credo.Check.Design.AliasUsage, priority: :low},
+
+        # For others you can set parameters
+
+        # If you don't want the `setup` and `test` macro calls in ExUnit tests
+        # or the `schema` macro in Ecto schemas to trigger DuplicatedCode, just
+        # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
+        #
+        {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
+
+        # You can also customize the exit_status of each check.
+        # If you don't want TODO comments to cause `mix credo` to fail, just
+        # set this value to 0 (zero).
+        #
+        {Credo.Check.Design.TagTODO, exit_status: 2},
+        {Credo.Check.Design.TagFIXME},
+
+        {Credo.Check.Readability.FunctionNames},
+        {Credo.Check.Readability.LargeNumbers},
+        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 135},
+        {Credo.Check.Readability.ModuleAttributeNames},
+        {Credo.Check.Readability.ModuleDoc},
+        {Credo.Check.Readability.ModuleNames},
+        {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
+        {Credo.Check.Readability.ParenthesesInCondition},
+        {Credo.Check.Readability.PredicateFunctionNames},
+        {Credo.Check.Readability.PreferImplicitTry, false},
+        {Credo.Check.Readability.RedundantBlankLines},
+        {Credo.Check.Readability.StringSigils},
+        {Credo.Check.Readability.TrailingBlankLine},
+        {Credo.Check.Readability.TrailingWhiteSpace},
+        {Credo.Check.Readability.VariableNames},
+        {Credo.Check.Readability.Semicolons},
+        {Credo.Check.Readability.SpaceAfterCommas},
+
+        {Credo.Check.Refactor.DoubleBooleanNegation},
+        {Credo.Check.Refactor.CondStatements},
+        {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 14},
+        {Credo.Check.Refactor.FunctionArity, max_arity: 7},
+        {Credo.Check.Refactor.LongQuoteBlocks},
+        {Credo.Check.Refactor.MatchInCondition},
+        {Credo.Check.Refactor.NegatedConditionsInUnless},
+        {Credo.Check.Refactor.NegatedConditionsWithElse},
+        {Credo.Check.Refactor.Nesting, max_nesting: 3},
+        {Credo.Check.Refactor.PipeChainStart},
+        {Credo.Check.Refactor.UnlessWithElse},
+
+        {Credo.Check.Warning.BoolOperationOnSameValues},
+        {Credo.Check.Warning.IExPry},
+        {Credo.Check.Warning.IoInspect},
+        {Credo.Check.Warning.LazyLogging},
+        {Credo.Check.Warning.OperationOnSameValues},
+        {Credo.Check.Warning.OperationWithConstantResult},
+        {Credo.Check.Warning.UnusedEnumOperation},
+        {Credo.Check.Warning.UnusedFileOperation},
+        {Credo.Check.Warning.UnusedKeywordOperation},
+        {Credo.Check.Warning.UnusedListOperation},
+        {Credo.Check.Warning.UnusedPathOperation},
+        {Credo.Check.Warning.UnusedRegexOperation},
+        {Credo.Check.Warning.UnusedStringOperation},
+        {Credo.Check.Warning.UnusedTupleOperation},
+        {Credo.Check.Warning.RaiseInsideRescue},
+
+        # Controversial and experimental checks (opt-in, just remove `, false`)
+        #
+        {Credo.Check.Refactor.ABCSize, false},
+        {Credo.Check.Refactor.AppendSingleItem, false},
+        {Credo.Check.Refactor.VariableRebinding, false},
+        {Credo.Check.Warning.MapGetUnsafePass, false},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
+
+        # Deprecated checks (these will be deleted after a grace period)
+        #
+        {Credo.Check.Readability.Specs, false},
+        {Credo.Check.Warning.NameRedeclarationByAssignment, false},
+        {Credo.Check.Warning.NameRedeclarationByCase, false},
+        {Credo.Check.Warning.NameRedeclarationByDef, false},
+        {Credo.Check.Warning.NameRedeclarationByFn, false},
+
+        # Custom checks can be created using `mix credo.gen.check`.
+        #
+      ]
+    }
+  ]
+}

--- a/lib/alchemist/helpers/module_info.ex
+++ b/lib/alchemist/helpers/module_info.ex
@@ -16,7 +16,8 @@ defmodule Alchemist.Helpers.ModuleInfo do
 
   def expand_alias([name | rest] = list, aliases) do
     module = Module.concat(Elixir, name)
-    Enum.find_value(aliases, list, fn {alias, mod} ->
+    aliases
+    |> Enum.find_value(list, fn {alias, mod} ->
       if alias === module do
         case Atom.to_string(mod) do
           "Elixir." <> mod ->
@@ -25,7 +26,8 @@ defmodule Alchemist.Helpers.ModuleInfo do
             mod
         end
       end
-    end) |> normalize_module
+    end)
+    |> normalize_module
   end
 
   def get_functions(module, hint) do
@@ -39,8 +41,9 @@ defmodule Alchemist.Helpers.ModuleInfo do
         false -> [{f, [a]}|acc]
       end
     end
-
-    do_get_functions(list, hint) |> :lists.sort()
+    list
+    |> do_get_functions(hint)
+    |> :lists.sort()
   end
 
   def has_function?(module, function) do
@@ -58,7 +61,10 @@ defmodule Alchemist.Helpers.ModuleInfo do
   defp get_module_funs(module) do
     case Code.ensure_loaded(module) do
       {:module, _} ->
-        (module.module_info(:functions) |> filter_module_funs) ++ module.__info__(:macros)
+        (:functions
+        |> module.module_info()
+        |> filter_module_funs)
+        ++ module.__info__(:macros)
       _otherwise ->
         []
     end

--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -90,7 +90,7 @@ defmodule ElixirSense do
       ["Version.Parser", "Version.Parser.DSL", "Version.Requirement", "WithClauseError"]
 
   """
-  def all_modules() do
+  def all_modules do
     Introspection.all_modules()
     |> Enum.map(&Atom.to_string(&1))
     |> Enum.map(fn x -> if String.downcase(x) == x do ":" <> x else x end end)

--- a/lib/elixir_sense/core/metadata.ex
+++ b/lib/elixir_sense/core/metadata.ex
@@ -1,4 +1,7 @@
 defmodule ElixirSense.Core.Metadata do
+  @moduledoc """
+  Core Metadata
+  """
 
   alias ElixirSense.Core.State
   alias ElixirSense.Core.Introspection
@@ -31,12 +34,15 @@ defmodule ElixirSense.Core.Metadata do
 
   def get_function_params(%__MODULE__{} = metadata, module, function) do
     params =
-      get_function_info(metadata, module, function)
+      metadata
+      |> get_function_info(module, function)
       |> Map.get(:params)
       |> Enum.reverse
 
     Enum.map(params, fn param ->
-      Macro.to_string(param) |> String.slice(1..-2)
+      param
+      |> Macro.to_string()
+      String.slice(1..-2)
     end)
   end
 
@@ -44,7 +50,8 @@ defmodule ElixirSense.Core.Metadata do
     docs = code_docs || Code.get_docs(module, :docs) || []
 
     params_list =
-      get_function_info(metadata, module, function)
+      metadata
+      |> get_function_info(module, function)
       |> Map.get(:params)
       |> Enum.reverse
 
@@ -57,7 +64,7 @@ defmodule ElixirSense.Core.Metadata do
           {Introspection.extract_summary_from_docs(text), Introspection.get_spec(module, function, arity)}
         end)
       %{name: Atom.to_string(function),
-        params: Enum.with_index(params) |> Enum.map(&Introspection.param_to_var/1),
+        params: params |> Enum.with_index() |> Enum.map(&Introspection.param_to_var/1),
         documentation: doc,
         spec: spec
       }

--- a/lib/elixir_sense/core/parser.ex
+++ b/lib/elixir_sense/core/parser.ex
@@ -1,4 +1,7 @@
 defmodule ElixirSense.Core.Parser do
+  @moduledoc """
+  Core Parser
+  """
 
   alias ElixirSense.Core.MetadataBuilder
   alias ElixirSense.Core.Metadata
@@ -93,7 +96,7 @@ defmodule ElixirSense.Core.Parser do
     # IO.puts :stderr, "REPLACING LINE: #{line}"
     source
     |> String.split(["\n", "\r\n"])
-    |> List.replace_at(line-1, "(__atom_elixir_marker_#{line}__())")
+    |> List.replace_at(line - 1, "(__atom_elixir_marker_#{line}__())")
     |> Enum.join("\n")
   end
 

--- a/lib/elixir_sense/core/source.ex
+++ b/lib/elixir_sense/core/source.ex
@@ -1,11 +1,14 @@
 defmodule ElixirSense.Core.Source do
+  @moduledoc """
+  Source parsing
+  """
 
   @empty_graphemes [" ", "\n", "\r\n"]
   @stop_graphemes ~w/{ } ( ) [ ] < > + - * & ^ , ; ~ % = " ' \\ \/ $ ! ?`#/ ++ @empty_graphemes
 
   def prefix(code, line, col) do
-    line = code |> String.split("\n") |> Enum.at(line-1)
-    line_str = line |> String.slice(0, col-1)
+    line = code |> String.split("\n") |> Enum.at(line - 1)
+    line_str = line |> String.slice(0, col - 1)
     case Regex.run(~r/[\w0-9\._!\?\:@]+$/, line_str) do
       nil -> ""
       [prefix] -> prefix
@@ -94,7 +97,7 @@ defmodule ElixirSense.Core.Source do
 
   def which_func(prefix) do
     tokens =
-      case prefix |> String.to_char_list |> :elixir_tokenizer.tokenize(1, []) do
+      case prefix |> String.to_charlist |> :elixir_tokenizer.tokenize(1, []) do
         {:ok, _, _, tokens} ->
           tokens |> Enum.reverse
         {:error, {_line, _error_prefix, _token}, _rest, sofar} ->
@@ -104,8 +107,8 @@ defmodule ElixirSense.Core.Source do
           # IO.inspect(:stderr, {:rest, rest}, [])
           sofar
       end
-
-    result = scan(tokens, %{npar: 0, count: 0, count2: 0, candidate: [], pos: nil, pipe_before: false })
+    pattern = %{npar: 0, count: 0, count2: 0, candidate: [], pos: nil, pipe_before: false}
+    result = scan(tokens, pattern)
     %{candidate: candidate, npar: npar, pipe_before: pipe_before, pos: pos} = result
 
     %{
@@ -154,7 +157,8 @@ defmodule ElixirSense.Core.Source do
     scan(tokens, %{state | candidate: [value|state.candidate], pos: update_pos(pos, state.pos)})
   end
   defp scan([{:aliases, pos, [value]}|tokens], %{count: 1} = state) do
-    scan(tokens, %{state | candidate: [Module.concat([value])|state.candidate], pos: update_pos(pos, state.pos)})
+    updated_pos = update_pos(pos, state.pos)
+    scan(tokens, %{state | candidate: [Module.concat([value])|state.candidate], pos: updated_pos})
   end
   defp scan([{:atom, pos, value}|tokens], %{count: 1} = state) do
     scan(tokens, %{state | candidate: [value|state.candidate], pos: update_pos(pos, state.pos)})

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -1,4 +1,7 @@
 defmodule ElixirSense.Core.State do
+  @moduledoc """
+  Core State
+  """
 
   defstruct [
     namespace:  [:Elixir],
@@ -17,6 +20,7 @@ defmodule ElixirSense.Core.State do
   ]
 
   defmodule Env do
+    @moduledoc false
     defstruct imports: [], requires: [], aliases: [], module: nil, vars: [], attributes: [], behaviours: [], scope: nil
   end
 
@@ -52,10 +56,11 @@ defmodule ElixirSense.Core.State do
   end
 
   def get_current_scope_name(state) do
-    case hd(state.scopes) do
+    scope = case hd(state.scopes) do
       {fun, _} -> fun
       mod      -> mod
-    end |> Atom.to_string
+    end
+    scope |> Atom.to_string()
   end
 
   def add_mod_fun_to_line(state, {module, fun, arity}, line, params) do
@@ -65,7 +70,8 @@ defmodule ElixirSense.Core.State do
     new_params = [params|current_params]
     new_lines = [line|current_lines]
 
-    %{state | mods_funs_to_lines: Map.put(state.mods_funs_to_lines, {module, fun, arity}, %{lines: new_lines, params: new_params})}
+    mods_funs_to_lines = Map.put(state.mods_funs_to_lines, {module, fun, arity}, %{lines: new_lines, params: new_params})
+    %{state | mods_funs_to_lines: mods_funs_to_lines}
   end
 
   def new_namespace(state, module) do
@@ -224,8 +230,9 @@ defmodule ElixirSense.Core.State do
       else
         [attribute|attributes_from_scope]
       end
-
-    %{state | attributes: [attributes_from_scope|other_attributes], scope_attributes: [attributes_from_scope|tl(state.scope_attributes)]}
+    attributes = [attributes_from_scope|other_attributes]
+    scope_attributes = [attributes_from_scope|tl(state.scope_attributes)]
+    %{state | attributes: attributes, scope_attributes: scope_attributes}
   end
 
   def add_behaviour(state, module) do

--- a/lib/elixir_sense/providers/docs.ex
+++ b/lib/elixir_sense/providers/docs.ex
@@ -1,5 +1,7 @@
 defmodule ElixirSense.Providers.Docs do
-
+  @moduledoc """
+  Doc Provider
+  """
   alias ElixirSense.Core.Introspection
 
   @spec all(String.t, [module], [{module, module}], module) :: {actual_mod_fun :: String.t, docs :: Introspection.docs}

--- a/lib/elixir_sense/providers/expand.ex
+++ b/lib/elixir_sense/providers/expand.ex
@@ -28,10 +28,10 @@ defmodule ElixirSense.Providers.Expand do
     try do
       {_, expr} = code |> Code.string_to_quoted
       %{
-        expand_once: Macro.expand_once(expr, env) |> Macro.to_string,
-        expand:  Macro.expand(expr, env) |> Macro.to_string,
-        expand_partial: Ast.expand_partial(expr, env) |> Macro.to_string,
-        expand_all: Ast.expand_all(expr, env) |> Macro.to_string,
+        expand_once:    expr |> Macro.expand_once(env)  |> Macro.to_string,
+        expand:         expr |> Macro.expand(env)       |> Macro.to_string,
+        expand_partial: expr |> Ast.expand_partial(env) |> Macro.to_string,
+        expand_all:     expr |> Ast.expand_all(env)     |> Macro.to_string,
       }
     rescue
       e ->

--- a/lib/elixir_sense/providers/signature.ex
+++ b/lib/elixir_sense/providers/signature.ex
@@ -28,10 +28,11 @@ defmodule ElixirSense.Providers.Signature do
 
   defp find_signatures({mod, fun}, metadata) do
     docs = Code.get_docs(mod, :docs)
-    case Metadata.get_function_signatures(metadata, mod, fun, docs) do
+    signatures = case Metadata.get_function_signatures(metadata, mod, fun, docs) do
       [] -> Introspection.get_signatures(mod, fun, docs)
       signatures -> signatures
-    end |> Enum.uniq_by(fn sig -> sig.params end)
+    end
+    signatures |> Enum.uniq_by(fn sig -> sig.params end)
   end
 
 end

--- a/lib/elixir_sense/server.ex
+++ b/lib/elixir_sense/server.ex
@@ -1,15 +1,20 @@
 defmodule ElixirSense.Server do
+  @moduledoc """
+  Server entry point and coordinator
+  """
+
+  alias ElixirSense.Server.TCPServer
 
   def start(args) do
     [socket_type, port, env] = validate_args(args)
     IO.puts(:stderr, "Initializing ElixirSense server for environment \"#{env}\" (Elixir version #{System.version})")
     IO.puts(:stderr, "Working directory is \"#{Path.expand(".")}\"")
-    ElixirSense.Server.TCPServer.start([socket_type: socket_type, port: port, env: env])
+    TCPServer.start([socket_type: socket_type, port: port, env: env])
     loop()
   end
 
   defp validate_args(["unix", _port, env] = args) do
-    {version, _} = :erlang.system_info(:otp_release) |> :string.to_integer
+    {version, _} = :otp_release |> :erlang.system_info() |> :string.to_integer()
     if version < 19 do
       IO.puts(:stderr, "Warning: Erlang version < 19. Cannot use Unix domain sockets. Using tcp/ip instead.")
       ["tcpip", "0", env]
@@ -21,7 +26,7 @@ defmodule ElixirSense.Server do
     args
   end
 
-  defp loop() do
+  defp loop do
     case IO.gets("") do
       :eof ->
         IO.puts(:stderr, "Stopping ElixirSense server")

--- a/lib/elixir_sense/server/context_loader.ex
+++ b/lib/elixir_sense/server/context_loader.ex
@@ -1,4 +1,7 @@
 defmodule ElixirSense.Server.ContextLoader do
+  @moduledoc """
+  Server Context Loader
+  """
   use GenServer
 
   @minimal_reload_time 2000
@@ -54,9 +57,9 @@ defmodule ElixirSense.Server.ContextLoader do
     end)
   end
 
-  defp all_loaded() do
+  defp all_loaded do
     preload_modules([Inspect, :base64, :crypto])
-    for {m,_} <- :code.all_loaded, do: m
+    for {m, _} <- :code.all_loaded, do: m
   end
 
   defp load_paths(env, cwd) do

--- a/lib/elixir_sense/server/request_handler.ex
+++ b/lib/elixir_sense/server/request_handler.ex
@@ -43,7 +43,7 @@ defmodule ElixirSense.Server.RequestHandler do
   end
 
   def handle_request("set_context", %{"env" => env, "cwd" => cwd}) do
-    ContextLoader.set_context(env, cwd) |> Tuple.to_list
+    env |> ContextLoader.set_context(cwd) |> Tuple.to_list()
   end
 
   def handle_request(request, payload) do

--- a/lib/elixir_sense/server/tcp_server.ex
+++ b/lib/elixir_sense/server/tcp_server.ex
@@ -1,4 +1,7 @@
 defmodule ElixirSense.Server.TCPServer do
+  @moduledoc """
+  TCP Server connection endpoint
+  """
   use Bitwise
 
   alias ElixirSense.Server.{RequestHandler, ContextLoader}
@@ -42,13 +45,15 @@ defmodule ElixirSense.Server.TCPServer do
   defp format_output("tcpip", host, port, auth_token) do
     "ok:#{host}:#{port}:#{auth_token}"
   end
+
   defp format_output("unix", host, file, _auth_token) do
     "ok:#{host}:#{file}"
   end
 
   defp listen_options("tcpip", port) do
-    {String.to_integer(port), @default_listen_options ++ [ip: {127,0,0,1}]}
+    {String.to_integer(port), @default_listen_options ++ [ip: {127, 0, 0, 1}]}
   end
+
   defp listen_options("unix", _port) do
     {0, @default_listen_options ++ [ifaddr: {:local, socket_file()}]}
   end
@@ -97,13 +102,17 @@ defmodule ElixirSense.Server.TCPServer do
     end
   end
 
-  defp dispatch_request(%{ "request_id" => request_id, "auth_token" => req_token, "request" => request, "payload" => payload }, auth_token) do
+  defp dispatch_request(%{
+    "request_id" => request_id,
+    "auth_token" => req_token,
+    "request" => request,
+    "payload" => payload}, auth_token) do
     if secure_compare(auth_token, req_token) do
       ContextLoader.reload()
       payload = RequestHandler.handle_request(request, payload)
-      %{request_id: request_id, payload: payload, error: nil }
+      %{request_id: request_id, payload: payload, error: nil}
     else
-      %{request_id: request_id, payload: nil, error: "unauthorized" }
+      %{request_id: request_id, payload: nil, error: "unauthorized"}
     end
   end
 
@@ -126,7 +135,9 @@ defmodule ElixirSense.Server.TCPServer do
     secure_compare(a_list, b_list)
   end
   defp secure_compare(a, b) when is_list(a) and is_list(b) do
-    res = Enum.zip(a, b) |> Enum.reduce(0, fn({a_byte, b_byte}, acc) ->
+    res = a
+    |> Enum.zip(b)
+    |> Enum.reduce(0, fn({a_byte, b_byte}, acc) ->
       acc ||| bxor(a_byte, b_byte)
     end)
     res == 0

--- a/mix.exs
+++ b/mix.exs
@@ -1,10 +1,11 @@
 defmodule ElixirSense.Mixfile do
+  @moduledoc false
   use Mix.Project
 
   def project do
     [app: :elixir_sense,
-     version: "0.1.0",
-     elixir: "~> 1.2",
+     version: "0.2.0",
+     elixir: "~> 1.5",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      test_coverage: [tool: ExCoveralls],
@@ -26,6 +27,7 @@ defmodule ElixirSense.Mixfile do
   defp deps do
     [{:excoveralls, "~> 0.6", only: :test},
     {:dialyxir, "~> 0.4", only: [:dev]},
+    {:credo, "~> 0.8.4", only: [:dev]},
     {:ex_doc, "~> 0.14", only: [:dev]}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [], [], "hexpm"},
+  "certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
+  "credo": {:hex, :credo, "0.8.4", "4e50acac058cf6292d6066e5b0d03da5e1483702e1ccde39abba385c9f03ead4", [], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.4.3", "a4daeebd0107de10d3bbae2ccb6b8905e69544db1ed5fe9148ad27cd4cb2c0cd", [:mix], []},
   "earmark": {:hex, :earmark, "1.1.0", "8c2bf85d725050a92042bc1edf362621004d43ca6241c756f39612084e95487f", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},


### PR DESCRIPTION
Code cleanup and Linting with Credo :+1: 
* replaced instances of the deprecated function `String.to_char_list/1` with `String.to_charlist/1`
* added the [credo](https://github.com/rrrene/credo) linter to the project, with a liberal ruleset to minimize the changes being made
* cleaned up all files so they pass credo's linter rules
* bumped the version to `0.2.0`, in anticipation of a future cut release of elixir_sense

Please get me feedback as soon as convenient. I would like to see these cleanups and changes get into the project within the next two weeks, so the Elixir atom and vscode plugins can be updated in time for ElixirConf in early September.