### PR TITLE
added an endpoint to return the current version info

### DIFF
--- a/lib/elixir_sense/server/request_handler.ex
+++ b/lib/elixir_sense/server/request_handler.ex
@@ -46,6 +46,13 @@ defmodule ElixirSense.Server.RequestHandler do
     env |> ContextLoader.set_context(cwd) |> Tuple.to_list()
   end
 
+  def handle_request("version", %{}) do
+    %{
+      elixir: System.version,
+      otp: System.otp_release
+    }
+  end
+
   def handle_request(request, payload) do
     IO.puts :stderr, "Cannot handle request \"#{request}\". Payload: #{inspect(payload)}"
   end


### PR DESCRIPTION
* added `handle_request("version", %{})`, which returns the current elixir and otp release version.
This can then be consumed to provide different functionality depending on elixir versions.