### PR TITLE
Small fixes, version endpoint

### DIFF
--- a/lib/elixir_sense/core/ast.ex
+++ b/lib/elixir_sense/core/ast.ex
@@ -33,12 +33,14 @@ defmodule ElixirSense.Core.Ast do
   end
 
   def expand_all(ast, env) do
-    {expanded_ast, _} = Macro.prewalk(ast, {env, 1}, &do_expand_all/2)
-    expanded_ast
-  rescue
-    _e -> ast
-  catch
-    e -> e
+    try do
+      {expanded_ast, _} = Macro.prewalk(ast, {env, 1}, &do_expand_all/2)
+      expanded_ast
+    rescue
+      _e -> ast
+    catch
+      e -> e
+    end
   end
 
   def set_module_for_env(env, module) do

--- a/lib/elixir_sense/server/request_handler.ex
+++ b/lib/elixir_sense/server/request_handler.ex
@@ -46,6 +46,13 @@ defmodule ElixirSense.Server.RequestHandler do
     env |> ContextLoader.set_context(cwd) |> Tuple.to_list()
   end
 
+  def handle_request("version", %{}) do
+    %{
+      elixir: System.version,
+      otp: System.otp_release
+    }
+  end
+
   def handle_request(request, payload) do
     IO.puts :stderr, "Cannot handle request \"#{request}\". Payload: #{inspect(payload)}"
   end


### PR DESCRIPTION
* added `handle_request("version", %{})`, which returns the current elixir and otp release version.
This can then be consumed to provide different functionality depending on elixir versions.
* fixed an ast parsing issue (my bad)
* changed a variable name