### PR TITLE
Use Regex.recompile!/1 on regexes to ensure Erlang/OTP version portab…

### DIFF
--- a/lib/elixir_sense/core/introspection.ex
+++ b/lib/elixir_sense/core/introspection.ex
@@ -409,7 +409,7 @@ defmodule ElixirSense.Core.Introspection do
     formatted_args =
       args
       |> Enum.map_join(",", &format_doc_arg(&1))
-      |> String.replace(~r/\s+/, " ")
+      |> String.replace(Regex.recompile!(~r/\s+/), " ")
     desc = extract_summary_from_docs(doc)
     {formatted_args, desc}
   end

--- a/lib/elixir_sense/core/parser.ex
+++ b/lib/elixir_sense/core/parser.ex
@@ -63,7 +63,7 @@ defmodule ElixirSense.Core.Parser do
   end
 
   defp fix_parse_error(source, _cursor_line_number, {:error, {_line, {_error_type, text}, _token}}) do
-    [_, line] = Regex.run(~r/line\s(\d+)/, text)
+    [_, line] = Regex.run(Regex.recompile!(~r/line\s(\d+)/), text)
     line = line |> String.to_integer
     source
     |> replace_line_with_marker(line)

--- a/lib/elixir_sense/core/source.ex
+++ b/lib/elixir_sense/core/source.ex
@@ -9,7 +9,7 @@ defmodule ElixirSense.Core.Source do
   def prefix(code, line, col) do
     line = code |> String.split("\n") |> Enum.at(line - 1)
     line_str = line |> String.slice(0, col - 1)
-    case Regex.run(~r/[\w0-9\._!\?\:@]+$/, line_str) do
+    case Regex.run(Regex.recompile!(~r/[\w0-9\._!\?\:@]+$/), line_str) do
       nil -> ""
       [prefix] -> prefix
     end

--- a/lib/elixir_sense/providers/definition.ex
+++ b/lib/elixir_sense/providers/definition.ex
@@ -41,7 +41,7 @@ defmodule ElixirSense.Providers.Definition do
     file = if file && File.exists?(file) do
       file
     else
-      erl_file = module |> :code.which |> to_string |> String.replace(~r/(.+)\/ebin\/([^\s]+)\.beam$/, "\\1/src/\\2.erl")
+      erl_file = module |> :code.which |> to_string |> String.replace(Regex.recompile!(~r/(.+)\/ebin\/([^\s]+)\.beam$/), "\\1/src/\\2.erl")
       if File.exists?(erl_file) do
         erl_file
       end
@@ -69,7 +69,7 @@ defmodule ElixirSense.Providers.Definition do
       file
       |> File.read!
       |> String.split(["\n", "\r\n"])
-      |> Enum.find_index(&String.match?(&1, ~r/^#{fun_name}\b/))
+      |> Enum.find_index(&String.match?(&1, Regex.recompile!(~r/^#{fun_name}\b/)))
 
     (index || 0) + 1
   end

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -140,8 +140,8 @@ defmodule ElixirSense.Providers.Suggestion do
           hint == "" or String.starts_with?("#{name}", hint)
       do
         desc = Introspection.extract_summary_from_docs(doc)
-        [_, args_str] = Regex.run(~r/.\((.*)\)/, signature)
-        args = args_str |> String.replace(~r/\s/, "")
+        [_, args_str] = Regex.run(Regex.recompile!(~r/.\((.*)\)/), signature)
+        args = args_str |> String.replace(Regex.recompile!(~r/\s/), "")
         %{type: :callback, name: name, arity: arity, args: args, origin: mod_name, summary: desc, spec: spec}
       end
     end) |> Enum.sort


### PR DESCRIPTION
…ility

See https://hexdocs.pm/elixir/Regex.html#module-precompilation for an explanation. Without this, these regexes can cause the VM to segfault if the ElixirSense beams were compiled with OTP 19 but the VM version is OTP 20.