### PR TITLE
Support finding definitions for defdelegate functions

### DIFF
--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -11,7 +11,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
 
   @scope_keywords [:for, :try, :fn]
   @block_keywords [:do, :else, :rescue, :catch, :after]
-  @defs [:def, :defp, :defmacro, :defmacrop]
+  @defs [:def, :defp, :defmacro, :defmacrop, :defdelegate]
 
   @doc """
   Traverses the AST building/retrieving the environment information.

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -640,6 +640,8 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
         IO.puts ""
         defmacro import(module, opts)
         IO.puts ""
+        defdelegate func_delegated(par), to: OtherModule
+        IO.puts ""
       end
       """
       |> string_to_state
@@ -651,6 +653,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     assert State.get_scope_name(state, 11) == {:macro1, 1}
     assert State.get_scope_name(state, 13) == :MyModule
     assert State.get_scope_name(state, 15) == :MyModule
+    assert State.get_scope_name(state, 16) == {:func_delegated, 1}
   end
 
   defp string_to_state(string) do

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -64,6 +64,17 @@ defmodule ElixirSense.Providers.DefinitionTest do
     assert read_line(file, {line, column}) =~ "flatten"
   end
 
+  test "find definition of delegated functions" do
+    buffer = """
+    defmodule MyModule do
+      String.length("elixir")
+    end
+    """
+    %{found: true, type: :function, file: file, line: line, column: column} = ElixirSense.definition(buffer, 2, 11)
+    assert file =~ "lib/elixir/lib/string.ex"
+    assert read_line(file, {line, column}) =~ "length"
+  end
+
   test "find definition of modules" do
     buffer = """
     defmodule MyModule do


### PR DESCRIPTION
In VSCode using https://github.com/JakeBecker/elixir-ls (which uses ElixirSense) when attempting to "Go To Definition" or "Peek Definition" for a function that delegates to a separate module (with `defdelegate`) you get a "No definition found" error.

This can be seen by attempting go to definition on the Elixir standard library function `String.length/1` which delegates to the `String.Unicode` module internally.

This PR enables finding `defdelegate` functions.