### PR TITLE
Tests dont require source

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 21.0.8
+elixir ref:v1.7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: erlang
+
+otp_release:
+  - '21.2'
+
+env:
+  EX_HOME: ${TRAVIS_BUILD_DIR}/elixir
+  EX_BIN: ${EX_HOME}/bin
+  ELIXIR: ${EX_BIN}/elixir
+  MIX: ${EX_BIN}/mix
+  EX_VSN: 1.7.1
+
+before_script:
+  - git clone https://github.com/elixir-lang/elixir.git ${EX_HOME}
+  - pushd ${EX_HOME}
+  - git checkout v${EX_VSN}
+  - make
+  - popd
+  - ${ELIXIR} ${MIX} local.hex --force
+  - ${ELIXIR} ${MIX} local.rebar --force
+
+script:
+  - ${ELIXIR} ${MIX} deps.get
+  - MIX_ENV=test ${ELIXIR} ${MIX} deps.compile
+  - ${ELIXIR} ${MIX} test

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ $ mix deps.get
 $ mix test
 ```
 
+A few of the tests require a source installation of Elixir which you can accomplish with [asdf](https://github.com/asdf-vm/asdf-elixir) (use `ref:v1.7.1`) or [kiex](https://github.com/taylor/kiex)
+
+To run the tests that require a source installation of Elixir run:
+```
+mix test --include requires_source
+```
+
 For coverage:
 
 ```

--- a/lib/elixir_sense/core/source.ex
+++ b/lib/elixir_sense/core/source.ex
@@ -131,11 +131,7 @@ defmodule ElixirSense.Core.Source do
   end
 
   def which_func(prefix) do
-    tokens =
-      prefix
-      |> String.to_charlist
-      |> :elixir_tokenizer.tokenize(1, [])
-      |> tokenize_prefix()
+    tokens = ElixirSense.Core.Tokenizer.tokenize(prefix)
 
     pattern = %{npar: 0, count: 0, count2: 0, candidate: [], pos: nil, pipe_before: false}
     result = scan(tokens, pattern)
@@ -147,20 +143,6 @@ defmodule ElixirSense.Core.Source do
       pipe_before: pipe_before,
       pos: pos
     }
-  end
-
-  defp tokenize_prefix({:ok, _, _, tokens}) do
-    tokens |> Enum.reverse
-  end
-
-  # Elixir >= 1.7
-  defp tokenize_prefix({:error, {_line, _column, _error_prefix, _token}, _rest, sofar}) do
-    sofar
-  end
-
-  # Elixir < 1.7
-  defp tokenize_prefix({:error, {_line, _error_prefix, _token}, _rest, sofar}) do
-    sofar
   end
 
   defp normalize_candidate(candidate) do

--- a/lib/elixir_sense/core/tokenizer.ex
+++ b/lib/elixir_sense/core/tokenizer.ex
@@ -1,0 +1,56 @@
+defmodule ElixirSense.Core.Tokenizer do
+  @moduledoc """
+  Handles tokenization of Elixir code snippets
+
+  Uses private api :elixir_tokenizer
+  """
+
+  def tokenize(prefix) do
+    prefix
+    |> String.to_charlist
+    |> do_tokenize(System.version())
+  end
+
+  defp do_tokenize(prefix_charlist, elixir_version) do
+    cond do
+      Version.match?(elixir_version, ">= 1.7.0") ->
+        do_tokenize_1_7(prefix_charlist)
+
+      Version.match?(elixir_version, ">= 1.6.0") ->
+        do_tokenize_1_6(prefix_charlist)
+
+      Version.match?(elixir_version, ">= 1.5.0") ->
+        do_tokenize_1_5(prefix_charlist)
+    end
+  end
+
+  defp do_tokenize_1_7(prefix_charlist) do
+    case :elixir_tokenizer.tokenize(prefix_charlist, 1, []) do
+      {:ok, tokens} ->
+        Enum.reverse(tokens)
+
+      {:error, {_line, _column, _error_prefix, _token}, _rest, sofar} ->
+        sofar
+    end
+  end
+
+  defp do_tokenize_1_6(prefix_charlist) do
+    case :elixir_tokenizer.tokenize(prefix_charlist, 1, []) do
+      {:ok, tokens} ->
+        Enum.reverse(tokens)
+
+      {:error, {_line, _error_prefix, _token}, _rest, sofar} ->
+        sofar
+    end
+  end
+
+  defp do_tokenize_1_5(prefix_charlist) do
+    case :elixir_tokenizer.tokenize(prefix_charlist, 1, []) do
+      {:ok, _, _, tokens} ->
+        Enum.reverse(tokens)
+
+      {:error, {_line, _error_prefix, _token}, _rest, sofar} ->
+        sofar
+    end
+  end
+end

--- a/test/elixir_sense/core/source_test.exs
+++ b/test/elixir_sense/core/source_test.exs
@@ -4,6 +4,10 @@ defmodule ElixirSense.Core.SourceTest do
   import ElixirSense.Core.Source
 
   describe "which_func/1" do
+    test "at the beginning of a defmodule" do
+      assert which_func("defmo") ==
+        %{candidate: :none, npar: 0, pipe_before: false, pos: nil}
+    end
 
     test "functions without namespace" do
       assert which_func("var = func(") == %{

--- a/test/elixir_sense/core/tokenizer_test.exs
+++ b/test/elixir_sense/core/tokenizer_test.exs
@@ -1,0 +1,51 @@
+defmodule ElixirSense.Core.TokenizerTest do
+  use ExUnit.Case
+
+  alias ElixirSense.Core.Tokenizer
+
+  describe "tokenize/1" do
+    test "functions wihtout namespace" do
+      assert Tokenizer.tokenize("var = func(") ==
+               [
+                 {:"(", {1, 11, nil}},
+                 {:paren_identifier, {1, 7, nil}, :func},
+                 {:match_op, {1, 5, nil}, :=},
+                 {:identifier, {1, 1, nil}, :var}
+               ]
+    end
+
+    test "functions with namespace" do
+      assert Tokenizer.tokenize("var = Mod.func(param1, par") == [
+               {:identifier, {1, 24, nil}, :par},
+               {:",", {1, 22, 0}},
+               {:identifier, {1, 16, nil}, :param1},
+               {:"(", {1, 15, nil}},
+               {:paren_identifier, {1, 11, nil}, :func},
+               {:., {1, 10, nil}},
+               {:alias, {1, 7, nil}, :Mod},
+               {:match_op, {1, 5, nil}, :=},
+               {:identifier, {1, 1, nil}, :var}
+             ]
+
+      assert Tokenizer.tokenize("var = Mod.SubMod.func(param1, param2, par") == [
+               {:identifier, {1, 39, nil}, :par},
+               {:",", {1, 37, 0}},
+               {:identifier, {1, 31, nil}, :param2},
+               {:",", {1, 29, 0}},
+               {:identifier, {1, 23, nil}, :param1},
+               {:"(", {1, 22, nil}},
+               {:paren_identifier, {1, 18, nil}, :func},
+               {:., {1, 17, nil}},
+               {:alias, {1, 11, nil}, :SubMod},
+               {:., {1, 10, nil}},
+               {:alias, {1, 7, nil}, :Mod},
+               {:match_op, {1, 5, nil}, :=},
+               {:identifier, {1, 1, nil}, :var}
+             ]
+    end
+
+    test "at the beginning of a defmodule" do
+      assert Tokenizer.tokenize("defmo") == [{:identifier, {1, 1, nil}, :defmo}]
+    end
+  end
+end

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -9,19 +9,21 @@ defmodule ElixirSense.Providers.DefinitionTest do
   test "find definition of aliased modules in `use`" do
     buffer = """
     defmodule MyModule do
-      alias Mix.Generator
-      use Generator
+      alias ElixirSenseExample.UseExample
+      use UseExample
+      #        ^
     end
     """
     %{found: true, type: :module, file: file, line: line, column: column} = ElixirSense.definition(buffer, 3, 12)
-    assert file =~ "lib/mix/lib/mix/generator.ex"
-    assert read_line(file, {line, column}) =~ "Mix.Generator"
+    assert file =~ "elixir_sense/test/support/use_example.ex"
+    assert read_line(file, {line, column}) =~ "ElixirSenseExample.UseExample"
   end
 
+  @tag requires_source: true
   test "find definition of functions from Kernel" do
     buffer = """
     defmodule MyModule do
-
+    #^
     end
     """
     %{found: true, type: :function, file: file, line: line, column: column} = ElixirSense.definition(buffer, 1, 2)
@@ -29,10 +31,12 @@ defmodule ElixirSense.Providers.DefinitionTest do
     assert read_line(file, {line, column}) =~ "defmodule("
   end
 
+  @tag requires_source: true
   test "find definition of functions from Kernel.SpecialForms" do
     buffer = """
     defmodule MyModule do
       import List
+       ^
     end
     """
     %{found: true, type: :function, file: file, line: line, column: column} = ElixirSense.definition(buffer, 2, 4)
@@ -43,37 +47,40 @@ defmodule ElixirSense.Providers.DefinitionTest do
   test "find definition of functions from imports" do
     buffer = """
     defmodule MyModule do
-      import Mix.Generator
-      create_file(
+      import ElixirSenseExample.ModuleWithFunctions
+      function_arity_zero()
+      #^
     end
     """
     %{found: true, type: :function, file: file, line: line, column: column} = ElixirSense.definition(buffer, 3, 4)
-    assert file =~ "lib/mix/lib/mix/generator.ex"
-    assert read_line(file, {line, column}) =~ "create_file"
+    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
+    assert read_line(file, {line, column}) =~ "function_arity_zero"
   end
 
   test "find definition of functions from aliased modules" do
     buffer = """
     defmodule MyModule do
-      alias List, as: MyList
-      MyList.flatten([[1],[3]])
+      alias ElixirSenseExample.ModuleWithFunctions, as: MyMod
+      MyMod.function_arity_one(42)
+      #        ^
     end
     """
     %{found: true, type: :function, file: file, line: line, column: column} = ElixirSense.definition(buffer, 3, 11)
-    assert file =~ "lib/elixir/lib/list.ex"
-    assert read_line(file, {line, column}) =~ "flatten"
+    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
+    assert read_line(file, {line, column}) =~ "function_arity_one"
   end
 
   test "find definition of modules" do
     buffer = """
     defmodule MyModule do
       alias List, as: MyList
-      String.to_atom("erlang")
+      ElixirSenseExample.ModuleWithFunctions.function_arity_zero()
+      #                   ^
     end
     """
-    %{found: true, type: :module, file: file, line: line, column: column} = ElixirSense.definition(buffer, 3, 4)
-    assert file =~ "lib/elixir/lib/string.ex"
-    assert read_line(file, {line, column}) =~ "String do"
+    %{found: true, type: :module, file: file, line: line, column: column} = ElixirSense.definition(buffer, 3, 23)
+    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
+    assert read_line(file, {line, column}) =~ "ElixirSenseExample.ModuleWithFunctions do"
   end
 
   test "find definition of erlang modules" do
@@ -81,6 +88,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     defmodule MyModule do
       def dup(x) do
         :lists.duplicate(2, x)
+        # ^
       end
     end
     """
@@ -94,6 +102,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     defmodule MyModule do
       def dup(x) do
         :lists.duplicate(2, x)
+        #         ^
       end
     end
     """
@@ -116,6 +125,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     defmodule MyModule do
       env = __ENV__
       IO.puts(env.file)
+      #            ^
     end
     """
     assert ElixirSense.definition(buffer, 3, 16) == %Location{found: false}
@@ -125,6 +135,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     buffer = """
     defmodule MyModule do
       var = %{count: 1}
+      #        ^
     end
     """
     assert ElixirSense.definition(buffer, 2, 12) == %Location{found: false}
@@ -134,19 +145,23 @@ defmodule ElixirSense.Providers.DefinitionTest do
     buffer = """
     defmodule MyModule do
       :erlang.node
+      # ^
     end
     """
     assert ElixirSense.definition(buffer, 2, 5) == %Location{found: false}
   end
 
   test "find the related module when searching for built-in functions" do
+    # module_info is defined by default for every elixir and erlang module:
+    # https://stackoverflow.com/a/33373107/175830
     buffer = """
     defmodule MyModule do
-      List.module_info()
+      ElixirSenseExample.ModuleWithFunctions.module_info()
+      #                                      ^
     end
     """
-    %{found: true, type: :function, file: file, line: 1, column: 1} = ElixirSense.definition(buffer, 2, 10)
-    assert file =~ "lib/elixir/lib/list.ex"
+    %{found: true, type: :function, file: file, line: 1, column: 1} = ElixirSense.definition(buffer, 2, 42)
+    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
   end
 
   test "find definition of variables" do
@@ -170,6 +185,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
       def func(%{a: [var2|_]}) do
         var1 = 3
         IO.puts(var1 + var2)
+        #               ^
       end
     end
     """

--- a/test/support/module_with_functions.ex
+++ b/test/support/module_with_functions.ex
@@ -1,0 +1,9 @@
+defmodule ElixirSenseExample.ModuleWithFunctions do
+  def function_arity_zero do
+    :return_value
+  end
+
+  def function_arity_one(_) do
+    nil
+  end
+end

--- a/test/support/use_example.ex
+++ b/test/support/use_example.ex
@@ -1,0 +1,9 @@
+defmodule ElixirSenseExample.UseExample do
+  defmacro __using__(_) do
+    quote do
+      def example do
+        42
+      end
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+ExUnit.configure(exclude: [requires_source: true])
 ExUnit.start()


### PR DESCRIPTION
Make most tests not require a source installation of Elixir, but those that do are only run with `mix test --include requires_source`

Accomplish this by creating `ElixirSenseExample.ModuleWithFunctions` and `ElixirSenseExample.UseExample` that live in the test/support directory

Add indicators in the example code to show where the cursor is