### PR TITLE
Make most tests not require a source installation of Elixir

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ $ mix deps.get
 $ mix test
 ```
 
+A few of the tests require a source installation of Elixir which you can accomplish with [asdf](https://github.com/asdf-vm/asdf-elixir) (use `ref:v1.7.1`) or [kiex](https://github.com/taylor/kiex)
+
+To run the tests that require a source installation of Elixir run:
+```
+mix test --include requires_source
+```
+
 For coverage:
 
 ```

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -9,19 +9,21 @@ defmodule ElixirSense.Providers.DefinitionTest do
   test "find definition of aliased modules in `use`" do
     buffer = """
     defmodule MyModule do
-      alias Mix.Generator
-      use Generator
+      alias ElixirSenseExample.UseExample
+      use UseExample
+      #        ^
     end
     """
     %{found: true, type: :module, file: file, line: line, column: column} = ElixirSense.definition(buffer, 3, 12)
-    assert file =~ "lib/mix/lib/mix/generator.ex"
-    assert read_line(file, {line, column}) =~ "Mix.Generator"
+    assert file =~ "elixir_sense/test/support/use_example.ex"
+    assert read_line(file, {line, column}) =~ "ElixirSenseExample.UseExample"
   end
 
+  @tag requires_source: true
   test "find definition of functions from Kernel" do
     buffer = """
     defmodule MyModule do
-
+    #^
     end
     """
     %{found: true, type: :function, file: file, line: line, column: column} = ElixirSense.definition(buffer, 1, 2)
@@ -29,10 +31,12 @@ defmodule ElixirSense.Providers.DefinitionTest do
     assert read_line(file, {line, column}) =~ "defmodule("
   end
 
+  @tag requires_source: true
   test "find definition of functions from Kernel.SpecialForms" do
     buffer = """
     defmodule MyModule do
       import List
+       ^
     end
     """
     %{found: true, type: :function, file: file, line: line, column: column} = ElixirSense.definition(buffer, 2, 4)
@@ -43,37 +47,40 @@ defmodule ElixirSense.Providers.DefinitionTest do
   test "find definition of functions from imports" do
     buffer = """
     defmodule MyModule do
-      import Mix.Generator
-      create_file(
+      import ElixirSenseExample.ModuleWithFunctions
+      function_arity_zero()
+      #^
     end
     """
     %{found: true, type: :function, file: file, line: line, column: column} = ElixirSense.definition(buffer, 3, 4)
-    assert file =~ "lib/mix/lib/mix/generator.ex"
-    assert read_line(file, {line, column}) =~ "create_file"
+    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
+    assert read_line(file, {line, column}) =~ "function_arity_zero"
   end
 
   test "find definition of functions from aliased modules" do
     buffer = """
     defmodule MyModule do
-      alias List, as: MyList
-      MyList.flatten([[1],[3]])
+      alias ElixirSenseExample.ModuleWithFunctions, as: MyMod
+      MyMod.function_arity_one(42)
+      #        ^
     end
     """
     %{found: true, type: :function, file: file, line: line, column: column} = ElixirSense.definition(buffer, 3, 11)
-    assert file =~ "lib/elixir/lib/list.ex"
-    assert read_line(file, {line, column}) =~ "flatten"
+    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
+    assert read_line(file, {line, column}) =~ "function_arity_one"
   end
 
   test "find definition of modules" do
     buffer = """
     defmodule MyModule do
       alias List, as: MyList
-      String.to_atom("erlang")
+      ElixirSenseExample.ModuleWithFunctions.function_arity_zero()
+      #                   ^
     end
     """
-    %{found: true, type: :module, file: file, line: line, column: column} = ElixirSense.definition(buffer, 3, 4)
-    assert file =~ "lib/elixir/lib/string.ex"
-    assert read_line(file, {line, column}) =~ "String do"
+    %{found: true, type: :module, file: file, line: line, column: column} = ElixirSense.definition(buffer, 3, 23)
+    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
+    assert read_line(file, {line, column}) =~ "ElixirSenseExample.ModuleWithFunctions do"
   end
 
   test "find definition of erlang modules" do
@@ -81,6 +88,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     defmodule MyModule do
       def dup(x) do
         :lists.duplicate(2, x)
+        # ^
       end
     end
     """
@@ -94,6 +102,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     defmodule MyModule do
       def dup(x) do
         :lists.duplicate(2, x)
+        #         ^
       end
     end
     """
@@ -116,6 +125,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     defmodule MyModule do
       env = __ENV__
       IO.puts(env.file)
+      #            ^
     end
     """
     assert ElixirSense.definition(buffer, 3, 16) == %Location{found: false}
@@ -125,6 +135,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     buffer = """
     defmodule MyModule do
       var = %{count: 1}
+      #        ^
     end
     """
     assert ElixirSense.definition(buffer, 2, 12) == %Location{found: false}
@@ -134,19 +145,23 @@ defmodule ElixirSense.Providers.DefinitionTest do
     buffer = """
     defmodule MyModule do
       :erlang.node
+      # ^
     end
     """
     assert ElixirSense.definition(buffer, 2, 5) == %Location{found: false}
   end
 
   test "find the related module when searching for built-in functions" do
+    # module_info is defined by default for every elixir and erlang module:
+    # https://stackoverflow.com/a/33373107/175830
     buffer = """
     defmodule MyModule do
-      List.module_info()
+      ElixirSenseExample.ModuleWithFunctions.module_info()
+      #                                      ^
     end
     """
-    %{found: true, type: :function, file: file, line: 1, column: 1} = ElixirSense.definition(buffer, 2, 10)
-    assert file =~ "lib/elixir/lib/list.ex"
+    %{found: true, type: :function, file: file, line: 1, column: 1} = ElixirSense.definition(buffer, 2, 42)
+    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
   end
 
   test "find definition of variables" do
@@ -170,6 +185,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
       def func(%{a: [var2|_]}) do
         var1 = 3
         IO.puts(var1 + var2)
+        #               ^
       end
     end
     """

--- a/test/support/module_with_functions.ex
+++ b/test/support/module_with_functions.ex
@@ -1,0 +1,9 @@
+defmodule ElixirSenseExample.ModuleWithFunctions do
+  def function_arity_zero do
+    :return_value
+  end
+
+  def function_arity_one(_) do
+    nil
+  end
+end

--- a/test/support/use_example.ex
+++ b/test/support/use_example.ex
@@ -1,0 +1,9 @@
+defmodule ElixirSenseExample.UseExample do
+  defmacro __using__(_) do
+    quote do
+      def example do
+        42
+      end
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+ExUnit.configure(exclude: [requires_source: true])
 ExUnit.start()


### PR DESCRIPTION
Make most tests not require a source installation of Elixir, but those that do are only run with `mix test --include requires_source`

Accomplish this by creating `ElixirSenseExample.ModuleWithFunctions` and `ElixirSenseExample.UseExample` that live in the test/support directory

Add indicators in the example code to show where the cursor is